### PR TITLE
Disable physics for kinematic test

### DIFF
--- a/worlds/Little Bicycle V2.wbt
+++ b/worlds/Little Bicycle V2.wbt
@@ -79,8 +79,7 @@ Robot {
             }
           ]
         }
-        physics Physics {
-        }
+        physics NULL
       }
     }
     DEF crank HingeJoint {
@@ -133,8 +132,7 @@ Robot {
                   }
                 ]
               }
-              physics Physics {
-              }
+              physics NULL
             }
           }
           DEF pedal HingeJoint {
@@ -166,8 +164,7 @@ Robot {
                   }
                 ]
               }
-              physics Physics {
-              }
+              physics NULL
             }
           }
         ]
@@ -196,8 +193,7 @@ Robot {
             }
           ]
         }
-        physics Physics {
-        }
+        physics NULL
       }
     }
     DEF Handlebars_and_Fork HingeJoint {
@@ -252,8 +248,7 @@ Robot {
                   }
                 ]
               }
-              physics Physics {
-              }
+              physics NULL
             }
           }
         ]
@@ -411,8 +406,7 @@ Robot {
             }
           ]
         }
-        physics Physics {
-        }
+        physics NULL
       }
     }
     Camera {
@@ -589,8 +583,7 @@ Robot {
       }
     ]
   }
-  physics Physics {
-  }
+  physics NULL
   controller "little_bicycle_P_V2"
   supervisor TRUE
 }


### PR DESCRIPTION
## Summary
- disable all `Physics` nodes in the world to remove physical influences

## Testing
- `python3 -m py_compile controllers/little_bicycle_P_V2/little_bicycle_P_V2.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2bd7e31c83238cf7c6688c4e75cf