### PR TITLE
Fix Supervisor proto reference

### DIFF
--- a/Regelstuerung/protos/Supervisor.proto
+++ b/Regelstuerung/protos/Supervisor.proto
@@ -1,0 +1,21 @@
+#VRML_SIM R2023b utf8
+
+PROTO Supervisor [
+  field SFVec3f translation 0 0 0
+  field SFRotation rotation 0 0 1 0
+  field MFNode children []
+  field SFString name ""
+  field SFString controller "<none>"
+  field MFString controllerArgs []
+]
+{
+  Robot {
+    translation IS translation
+    rotation IS rotation
+    children IS children
+    name IS name
+    controller IS controller
+    controllerArgs IS controllerArgs
+    supervisor TRUE
+  }
+}

--- a/Regelstuerung/worlds/Little Bicycle V2.wbt
+++ b/Regelstuerung/worlds/Little Bicycle V2.wbt
@@ -3,7 +3,7 @@
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/floors/protos/RectangleArena.proto"
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/backgrounds/protos/TexturedBackground.proto"
 EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
-EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/projects/default/protos/Supervisor.proto"
+EXTERNPROTO "../protos/Supervisor.proto"
 
 WorldInfo {
   basicTimeStep 2


### PR DESCRIPTION
## Summary
- add local `Supervisor.proto` to avoid failed download
- update world file to reference the local proto

## Testing
- `python -m py_compile Regelstuerung/test_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68652fc4b62083238a430fa3583e2e2b