### PR TITLE
Disable disturbances and noise in IMU

### DIFF
--- a/Fahrbahnerkennung/controllers/little_bicycle_P_V2/little_bicycle_P_V2.py
+++ b/Fahrbahnerkennung/controllers/little_bicycle_P_V2/little_bicycle_P_V2.py
@@ -145,6 +145,8 @@ disturbance_interval = 15.0  # Durchschnittliches Zeitintervall zwischen Störun
 max_disturbance = 0.2        # Maximale Stärke der Störung
 current_disturbance = 0.0    # Aktuelle aktive Störung
 disturbance_decay = 0.95     # Abklingfaktor der Störung pro Zeitschritt
+# Störungen können über diese Variable ein- bzw. ausgeschaltet werden
+disturbance_enabled = False
 
 def calculate_air_resistance(speed):
     """
@@ -683,6 +685,9 @@ def apply_random_disturbance(dt):
         float: Störeffekt, der auf den Lenkwinkel angewendet werden soll.
     """
     global last_disturbance_time, current_disturbance
+
+    if not disturbance_enabled:
+        return 0.0
     
     current_time = robot.getTime()
     

--- a/Regelstuerung/worlds/Normal_World_normallBike copy.wbt
+++ b/Regelstuerung/worlds/Normal_World_normallBike copy.wbt
@@ -510,6 +510,7 @@ DEF BICYCLE Robot {
       translation 0 0 0.32
       rotation 1 0 0 0
       name "imu"
+      noise 0
     }
     Receiver {
       name "command_rx"

--- a/Regelstuerung/worlds/Normal_World_smallBike.wbt
+++ b/Regelstuerung/worlds/Normal_World_smallBike.wbt
@@ -586,6 +586,7 @@ DEF BICYCLE Robot {#Beginn des Robot Roots
       translation 0 0 0.05
       rotation 1 0 0 0
       name "imu"
+      noise 0
     }
     Receiver { #Definition des Empfängers
       name "command_rx"


### PR DESCRIPTION
## Summary
- allow switching random disturbances off in the controller
- explicitly set the `InertialUnit` noise to `0` in world files

## Testing
- `python3 -m py_compile Fahrbahnerkennung/controllers/little_bicycle_P_V2/little_bicycle_P_V2.py`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c061feed0832386e4fdeb86c031ae