### PR TITLE
Update handlebar limit to 0.5 rad

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ whemotor.setVelocity(bcyS)
 ```
 Die Regelung verringert die Geschwindigkeit bei größeren Abweichungen und stellt den Lenkwinkel entsprechend ein.
 
+Der maximal zulässige Lenkwinkel wurde auf **0.5 rad** (≈29°) erhöht, was nun deutlich engere Kurven ermöglicht.
+
 ## Systemüberblick
 Eine vereinfachte Blockdarstellung der Regelstrecke:
 ```

--- a/README_Regelschleifen.md
+++ b/README_Regelschleifen.md
@@ -281,7 +281,7 @@ float get_filtered_roll_angle(void) {
             "stability_factor": 0.5
         },
         "system": {
-            "max_handlebar_angle": 0.32,
+            "max_handlebar_angle": 0.5,
             "max_roll_angle": 45.0,
             "filter_size": 5,
             "enable_logging": true
@@ -300,7 +300,7 @@ balance_params = {
     "Angle PID Ki": {"value": 0.0, "min": 0.0, "max": 10.0},
     "Angle PID Kd": {"value": 2.2, "min": 0.0, "max": 10.0},
     "Base Speed": {"value": 5.0, "min": 1.0, "max": 10.0},
-    "Max Handlebar Angle": {"value": 0.32, "min": 0.1, "max": 0.5}
+    "Max Handlebar Angle": {"value": 0.5, "min": 0.1, "max": 0.8}
 }
 ```
 

--- a/Regelstuerung/GUI/balance_config.json
+++ b/Regelstuerung/GUI/balance_config.json
@@ -16,7 +16,7 @@
             "stability_reduction": 0.5
         },
         "mechanical_limits": {
-            "max_handlebar_angle": 0.32,
+            "max_handlebar_angle": 0.5,
             "max_roll_angle": 45.0
         },
         "system": {

--- a/Regelstuerung/GUI/balance_controller_gui.py
+++ b/Regelstuerung/GUI/balance_controller_gui.py
@@ -109,7 +109,7 @@ class BalanceControllerGUI:
             # Mechanical Limits
             "max_handlebar_angle": {
                 "name": "Max. Lenkwinkel",
-                "value": 0.32,
+                "value": 0.5,
                 "min": 0.1,
                 "max": 0.8,
                 "description": "Maximaler physischer Lenkwinkel",
@@ -1064,7 +1064,7 @@ class BalanceControllerGUI:
             "angle_Kp": 10.0, "angle_Ki": 0.0, "angle_Kd": 2.2,
             "angle_output_min": -0.3, "angle_output_max": 0.3,
             "base_speed": 5.0, "min_speed": 3.0, "max_speed": 8.0, "stability_reduction": 0.5,
-            "max_handlebar_angle": 0.32, "max_roll_angle": 45.0
+            "max_handlebar_angle": 0.5, "max_roll_angle": 45.0
         }
         
         for key, value in defaults.items():

--- a/Regelstuerung/controllers/balance_control_c/balance_config.c
+++ b/Regelstuerung/controllers/balance_control_c/balance_config.c
@@ -184,7 +184,7 @@ void balance_config_set_defaults(balance_config_t *config) {
     config->speed_control.stability_reduction = 0.5f; // 50% Reduktion bei max. Lenkwinkel
     
     // Mechanical Limits
-    config->mechanical_limits.max_handlebar_angle = 0.32f; // ~18° in Radiant
+    config->mechanical_limits.max_handlebar_angle = 0.5f; // ~29° in Radiant
     config->mechanical_limits.max_roll_angle = 45.0f;      // 45° maximaler Roll-Winkel
     
     // System Settings


### PR DESCRIPTION
## Summary
- raise `max_handlebar_angle` default to 0.5 rad in C config
- reflect updated limit in GUI defaults and JSON config
- document new steering limit in README files

## Testing
- `make -C Regelstuerung/controllers/balance_control_c` *(fails: M_PI undeclared)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e352ad2483239b5df52c68fdbfa9