### PR TITLE
Fix IMU quaternion order

### DIFF
--- a/README_PHYSIK_IMPLEMENTIERUNG.md
+++ b/README_PHYSIK_IMPLEMENTIERUNG.md
@@ -245,10 +245,11 @@ static float get_filtered_roll_angle(void) {
     const double *quaternion = wb_inertial_unit_get_quaternion(imu_sensor);
     
     // Quaternion zu Euler-Winkel (Roll um X-Achse)
-    double w = quaternion[0];
-    double x = quaternion[1]; 
-    double y = quaternion[2];
-    double z = quaternion[3];
+    // Reihenfolge in Webots: (x, y, z, w)
+    double x = quaternion[0];
+    double y = quaternion[1];
+    double z = quaternion[2];
+    double w = quaternion[3];
     
     // Normalisierung (Sicherheitscheck)
     double norm = sqrt(w*w + x*x + y*y + z*z);

--- a/README_Regelschleifen.md
+++ b/README_Regelschleifen.md
@@ -231,10 +231,11 @@ float get_filtered_roll_angle(void) {
     const double *quaternion = wb_inertial_unit_get_quaternion(imu_sensor);
     
     // Quaternion zu Euler-Winkel (Roll um X-Achse)
-    double w = quaternion[0];
-    double x = quaternion[1]; 
-    double y = quaternion[2];
-    double z = quaternion[3];
+    // Webots liefert die Werte als (x, y, z, w)
+    double x = quaternion[0];
+    double y = quaternion[1];
+    double z = quaternion[2];
+    double w = quaternion[3];
     
     // Roll-Winkel berechnen
     double roll_rad = atan2(2 * (w * x + y * z), w*w - x*x - y*y + z*z);

--- a/Regelstuerung/DETAILED_COMPARISON_README.md
+++ b/Regelstuerung/DETAILED_COMPARISON_README.md
@@ -200,7 +200,7 @@ float roll_rad = atan2(2*(w*x + y*z), w*w - x*x - y*y + z*z);
 ```
 
 **Eigenschaften:**
-- **Datenformat**: Quaternion (w, x, y, z)
+- **Datenformat**: Quaternion (x, y, z, w)
 - **Messrate**: 200 Hz (5ms Webots-Timestep)
 - **Rauschen**: Simuliert durch erweiterte Physik
 - **Präzision**: Floating-Point-Genauigkeit

--- a/Regelstuerung/controllers/balance_control_c/README_BALANCE_REGELUNG.md
+++ b/Regelstuerung/controllers/balance_control_c/README_BALANCE_REGELUNG.md
@@ -429,7 +429,8 @@ bicycle_physics.o: bicycle_physics.c bicycle_physics.h
 static float get_filtered_roll_angle(void) {
     // IMU-Quaternion auslesen
     const double *quaternion = wb_inertial_unit_get_quaternion(imu_sensor);
-    double w = quaternion[0], x = quaternion[1], y = quaternion[2], z = quaternion[3];
+    // Reihenfolge: (x, y, z, w)
+    double x = quaternion[0], y = quaternion[1], z = quaternion[2], w = quaternion[3];
     
     // Quaternion → Roll-Winkel
     float roll_rad = atan2(2*(w*x + y*z), w*w - x*x - y*y + z*z);

--- a/Regelstuerung/controllers/balance_control_c/balance_control_c.c
+++ b/Regelstuerung/controllers/balance_control_c/balance_control_c.c
@@ -411,18 +411,19 @@ static double last_command_time = 0.0;
          return 0.0;  // Fallback bei Sensor-Fehler
      }
      
-     // Quaternion zu Euler-Winkel (Roll um X-Achse)
-     double w = quaternion[0];
-     double x = quaternion[1]; 
-     double y = quaternion[2];
-     double z = quaternion[3];
+    // Quaternion zu Euler-Winkel (Roll um X-Achse)
+    // Webots liefert Quaternionen im Format (x, y, z, w)
+    double x = quaternion[0];
+    double y = quaternion[1];
+    double z = quaternion[2];
+    double w = quaternion[3];
      
-     // DEBUG: Quaternion-Werte ausgeben (nur alle 40 Zyklen = 200ms)
-     static int debug_counter = 0;
-     if (++debug_counter >= 40) {
-         printf("DEBUG: Quaternion [w=%.6f, x=%.6f, y=%.6f, z=%.6f]\n", w, x, y, z);
-         debug_counter = 0;
-     }
+    // DEBUG: Quaternion-Werte ausgeben (nur alle 40 Zyklen = 200ms)
+    static int debug_counter = 0;
+    if (++debug_counter >= 40) {
+        printf("DEBUG: Quaternion [x=%.6f, y=%.6f, z=%.6f, w=%.6f]\n", x, y, z, w);
+        debug_counter = 0;
+    }
      
      // Normalisierung (Sicherheitscheck)
      double norm = sqrt(w*w + x*x + y*y + z*z);


### PR DESCRIPTION
## Summary
- use correct quaternion component order from Webots (x,y,z,w)
- update documentation examples accordingly

## Testing
- `make clean && make all` *(fails: webots headers missing)*
- `python3 -m py_compile Regelstuerung/test_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_688ce1050c988323855a198105d84954