### PR TITLE
Reduce IMU noise and increase roll filter

### DIFF
--- a/Regelstuerung/controllers/balance_control_c/balance_pid.h
+++ b/Regelstuerung/controllers/balance_control_c/balance_pid.h
@@ -9,7 +9,7 @@
 #define BALANCE_PID_H
 
 #define HISTORY_LEN 5
-#define ROLL_FILTER_SIZE 10
+#define ROLL_FILTER_SIZE 30
 
 typedef struct {
     // Historie für D-Term-Berechnung

--- a/Regelstuerung/worlds/Normal_World_normallBike copy.wbt
+++ b/Regelstuerung/worlds/Normal_World_normallBike copy.wbt
@@ -510,6 +510,7 @@ DEF BICYCLE Robot {
       translation 0 0 0.32
       rotation 1 0 0 0
       name "imu"
+      noise 0.0
     }
     Receiver {
       name "command_rx"


### PR DESCRIPTION
## Summary
- disable noise in the IMU sensor in the world file
- extend the roll angle filter to smooth the signal longer

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d127713888323bf63e7b7edde2ad8